### PR TITLE
[FIX] Avoid updating dependencies if pinned by odoo

### DIFF
--- a/bin/oca_install_addons__deps_and_addons_path
+++ b/bin/oca_install_addons__deps_and_addons_path
@@ -39,4 +39,4 @@ fi
 cat test-constraints.txt
 
 # Install dependencies of addons to test.
-pip install -r test-requirements.txt -c test-constraints.txt
+pip install -r test-requirements.txt -c test-constraints.txt -c /opt/odoo/requirements.txt


### PR DESCRIPTION
Around https://github.com/OCA/l10n-spain/actions/runs/7707368084/job/21004431015?pr=3389#step:4:347 you can see these logs:

```
+ cat test-requirements.txt
[...]
cryptography
[...]
Requirement already satisfied: cryptography in /opt/odoo-venv/lib/python3.10/site-packages (from -r test-requirements.txt (line 3)) (3.4.8)
[...]
Collecting cryptography (from -r test-requirements.txt (line 3))
  Downloading cryptography-42.0.1-cp39-abi3-manylinux_2_28_x86_64.whl.metadata (5.3 kB)
[...]
  Attempting uninstall: cryptography
    Found existing installation: cryptography 3.4.8
    Uninstalling cryptography-3.4.8:
      Successfully uninstalled cryptography-3.4.8
Successfully installed [...] cryptography-42.0.1 [...]
```

These reveal that for some reason, adding `cryptography` to `test-requirements.txt` makes pip update it, when it should just stay with [the version pinned by odoo](https://github.com/odoo/odoo/blob/604a8a15cb637fa98b42fa9da0337975469416e4/requirements.txt#L5).

Here I'm adding upstream requirements as a constraints file, so that OCA workloads don't attempt to install any dependency that is pinned there.

@moduon MT-4799 @sbidoul